### PR TITLE
fix: pass timeout_seconds to Sandbox.run() instead of constructor

### DIFF
--- a/implementation/playground_s3e1.py
+++ b/implementation/playground_s3e1.py
@@ -125,9 +125,10 @@ IMPORTANT CONSTRAINTS FOR SPEED:
         return futs.Solution(code)
 
 class PlaygroundExecutor:
-    def __init__(self, sandbox: Sandbox, y_true: np.ndarray):
+    def __init__(self, sandbox: Sandbox, y_true: np.ndarray, timeout_seconds: int = 60):
         self.sandbox = sandbox
         self.y_true = y_true
+        self.timeout_seconds = timeout_seconds
 
     def __call__(self, problem: futs.Problem, solution: futs.Solution) -> float:
         # ... (setup code remains similar)
@@ -161,7 +162,7 @@ def wrapper(unused_arg):
 """
         final_program = full_program + wrapper_code
         
-        result, success = self.sandbox.run(final_program, "wrapper", None)
+        result, success = self.sandbox.run(final_program, "wrapper", "None", self.timeout_seconds)
         
         if not success or result is None:
             print(f"Execution failed: {result}")
@@ -195,7 +196,9 @@ def run_experiment(iterations=10):
     y_val = prepare_data()
 
     llm = GeminiLLM(api_key)
-    sandbox = Sandbox(timeout_seconds=60) # Give it time to train
+    # `timeout_seconds` is a per-run argument on Sandbox.run(), not a constructor
+    # argument. Plug in your own concrete Sandbox implementation here.
+    sandbox = Sandbox()
     
     problem = PlaygroundProblem("Improve the regression model for the California Housing dataset.")
     
@@ -220,7 +223,7 @@ def train_and_predict(train_path, test_path):
     initial_solution = futs.Solution(initial_code)
     
     # Evaluate initial
-    executor = PlaygroundExecutor(sandbox, y_val)
+    executor = PlaygroundExecutor(sandbox, y_val, timeout_seconds=60)
     print("Evaluating initial solution...")
     initial_score = executor(problem, initial_solution)
     print(f"Initial Score (Neg RMSE): {initial_score}")


### PR DESCRIPTION
## What

The `playground_s3e1.py` example fails at startup with:

```
TypeError: Sandbox() takes no arguments
```

The `Sandbox` interface in `implementation/sandbox.py` defines `timeout_seconds`
as a **per-call** argument of
`run(program, function_to_run, test_input, timeout_seconds)`, but the example
passed it to the **constructor** as `Sandbox(timeout_seconds=60)`. Since
`Sandbox` defines no `__init__`, this raises `TypeError`.

## Changes

- Construct `Sandbox()` with no arguments and plumb the timeout through
  `PlaygroundExecutor` to the `run()` call.
- Add the missing `timeout_seconds` argument to the `run()` call (it was being
  called with only 3 of its 4 required arguments).
- Pass `test_input` as `"None"` (a `str`) to match the `run()` signature's
  `test_input: str` type hint.

This corrects the example against the existing abstract `Sandbox` contract; a
concrete `Sandbox` implementation still needs to be supplied to actually execute
code, as noted in the interface.

## Notes

I have (or will) sign the Google CLA to cover this contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)